### PR TITLE
Update NgScopeCellDci struct

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,12 +80,14 @@ fn start_listen_for_ngscope_message() -> Result<()> {
             match msg {
                 Message::Start => {}
                 Message::CellDci(cell_dci) => {
-                    println!("<THESIS> {:?} | {:03?} | {:03?} | {:08?} | {:08?}",
+                    println!("<THESIS> {:?} | {:03?} | {:03?} | {:08?} | {:08?} | {:03?} | {:03?}",
                           cell_dci.nof_rnti,
                           cell_dci.total_dl_prb,
                           cell_dci.total_ul_prb,
                           cell_dci.total_dl_tbs,
-                          cell_dci.total_ul_tbs);
+                          cell_dci.total_ul_tbs,
+                          cell_dci.total_dl_reTx,
+                          cell_dci.total_ul_reTx);
                 }
                 Message::Dci(ue_dci) => {
                     println!("{:?}", ue_dci)

--- a/src/ngscope/types.rs
+++ b/src/ngscope/types.rs
@@ -7,13 +7,13 @@ pub const NOF_VALIDATE_SUCCESS: usize = 2;
 pub const NGSCOPE_REMOTE_BUFFER_SIZE: usize = 1400; // ngscope sending buffer size
                                                 // taken from: ngscope/hdr/dciLib/dci_sink_def.h
 pub const NGSCOPE_MAX_NOF_CELL: usize = 4; // ngscope max nof cells per station
-pub const NGSCOPE_MAX_NOF_RNTI: usize = 10;
+pub const NGSCOPE_MAX_NOF_RNTI: usize = 20;
 
 pub const NGSCOPE_MESSAGE_TYPE_SIZE: usize = 4;
 pub const NGSCOPE_MESSAGE_VERSION_POSITION: usize = 4;
 pub const NGSCOPE_MESSAGE_CONTENT_POSITION: usize = 5;
 pub const NGSCOPE_STRUCT_SIZE_DCI: usize = 40;
-pub const NGSCOPE_STRUCT_SIZE_CELL_DCI: usize = 248; // TODO: Determine this actually
+pub const NGSCOPE_STRUCT_SIZE_CELL_DCI: usize = 448;
 pub const NGSCOPE_STRUCT_SIZE_CONFIG: usize = 12; // TODO: Determine this actually
 
 // IMPORTANT:
@@ -116,9 +116,11 @@ pub struct NgScopeRntiDci {
     pub rnti: u16,
 	pub dl_tbs: u32,
 	pub dl_prb: u8,
+	pub dl_reTx: u8,
 
 	pub ul_tbs: u32,
 	pub ul_prb: u8,
+	pub ul_reTx: u8,
 }
 
 #[repr(C)]
@@ -131,7 +133,8 @@ pub struct NgScopeCellDci {
 	pub total_ul_tbs: u64,
 	pub total_dl_prb: u8,
 	pub total_ul_prb: u8,
-	// TODO: Evaluate MAX_NOF_RNTI
+	pub total_dl_reTx: u8,
+	pub total_ul_reTx: u8,
 	pub nof_rnti: u8,
     pub rnti_list: [NgScopeRntiDci; NGSCOPE_MAX_NOF_RNTI],
 }


### PR DESCRIPTION
Add per-RNTI and total reTX:

reTX determines whether a ul/dl re-transmission occured in a DCI