### PR TITLE
Feature/workflow ngcontrol

### DIFF
--- a/src/logic/cell_sink.rs
+++ b/src/logic/cell_sink.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use bus::BusReader;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::SyncSender;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -12,7 +12,7 @@ use crate::logic::{
 
 pub struct CellSinkArgs {
     pub rx_app_state: BusReader<WorkerState>,
-    pub tx_sink_state: Sender<WorkerState>,
+    pub tx_sink_state: SyncSender<WorkerState>,
     pub rx_cell_info: BusReader<MessageCellInfo>,
     pub rx_dci: BusReader<MessageDci>,
     pub rx_rnti: BusReader<MessageRnti>,
@@ -31,13 +31,13 @@ pub fn deploy_cell_sink(args: CellSinkArgs) -> Result<JoinHandle<()>> {
     Ok(thread)
 }
 
-fn send_final_state(tx_sink_state: &Sender<WorkerState>) -> Result<()> {
+fn send_final_state(tx_sink_state: &SyncSender<WorkerState>) -> Result<()> {
     Ok(tx_sink_state.send(WorkerState::Stopped(WorkerType::CellSink))?)
 }
 
 fn wait_for_running(
     rx_app_state: &mut BusReader<WorkerState>,
-    tx_sink_state: &Sender<WorkerState>,
+    tx_sink_state: &SyncSender<WorkerState>,
 ) -> Result<()> {
     match wait_until_running(rx_app_state) {
         Ok(_) => Ok(()),
@@ -50,7 +50,7 @@ fn wait_for_running(
 
 fn run(
     mut rx_app_state: BusReader<WorkerState>,
-    tx_sink_state: Sender<WorkerState>,
+    tx_sink_state: SyncSender<WorkerState>,
     _rx_cell_info: BusReader<MessageCellInfo>,
     _rx_dci: BusReader<MessageDci>,
     _rx_rnti: BusReader<MessageRnti>,

--- a/src/logic/cell_source.rs
+++ b/src/logic/cell_source.rs
@@ -12,6 +12,10 @@ use crate::logic::{
 };
 use crate::parse::{Arguments, FlattenedCellApiConfig};
 
+
+const WAIT_TO_RETRIEVE_CELL_INFO_MS: u64 = 500;
+
+
 pub struct CellSourceArgs {
     pub rx_app_state: BusReader<WorkerState>,
     pub tx_source_state: Sender<WorkerState>,
@@ -36,11 +40,11 @@ fn send_final_state(tx_sink_state: &Sender<WorkerState>) -> Result<()> {
 }
 
 fn wait_for_running(
-    rx_app_state: BusReader<WorkerState>,
+    rx_app_state: &mut BusReader<WorkerState>,
     tx_source_state: &Sender<WorkerState>,
-) -> Result<BusReader<WorkerState>> {
+) -> Result<()> {
     match wait_until_running(rx_app_state) {
-        Ok(rx_app) => Ok(rx_app),
+        Ok(_) => Ok(()),
         _ => {
             send_final_state(tx_source_state)?;
             Err(anyhow!("[source] Main did not send 'Running' message"))
@@ -68,7 +72,8 @@ fn run(
     mut tx_cell_info: Bus<MessageCellInfo>,
 ) -> Result<()> {
     tx_source_state.send(WorkerState::Running(WorkerType::CellSource))?;
-    rx_app_state = wait_for_running(rx_app_state, &tx_source_state)?;
+    wait_for_running(&mut rx_app_state, &tx_source_state)?;
+
     let cell_api_args = FlattenedCellApiConfig::from_unflattened(
         app_args.cellapi.unwrap(),
         app_args.milesight.unwrap(),
@@ -81,9 +86,8 @@ fn run(
     loop {
         /* <precheck> */
         thread::sleep(Duration::from_millis(DEFAULT_WORKER_SLEEP_MS));
-        match check_not_stopped(rx_app_state) {
-            Ok(rx_app) => rx_app_state = rx_app,
-            _ => break,
+        if check_not_stopped(&mut rx_app_state).is_err() {
+            break;
         }
         /* </precheck> */
 
@@ -100,7 +104,7 @@ fn run(
             },
         }
 
-        thread::sleep(Duration::from_secs(5));
+        thread::sleep(Duration::from_millis(WAIT_TO_RETRIEVE_CELL_INFO_MS - DEFAULT_WORKER_SLEEP_MS));
     }
 
     send_final_state(&tx_source_state)?;

--- a/src/logic/ngscope_controller.rs
+++ b/src/logic/ngscope_controller.rs
@@ -1,30 +1,34 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bus::{Bus, BusReader};
 use std::net::UdpSocket;
 use std::process::Child;
-use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::{Sender, TryRecvError};
-use std::sync::Arc;
+use std::sync::mpsc::{Sender, TryRecvError, Receiver, channel};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
 use crate::cell_info::CellInfo;
 use crate::logic::{
-    check_not_stopped,
+    check_not_stopped, wait_until_running, send_explicit_state,
     MessageCellInfo, MessageDci, WorkerState, WorkerType,
+    ExplicitWorkerState, NgControlState,
     DEFAULT_WORKER_SLEEP_MS,
 };
 use crate::ngscope;
 use crate::ngscope::config::NgScopeConfig;
 use crate::ngscope::types::Message;
 use crate::ngscope::{restart_ngscope, start_ngscope, stop_ngscope};
-use crate::parse::{Arguments, MilesightArgs};
-use crate::util;
+use crate::parse::Arguments;
+
+
+enum LocalDciState {
+    Stop,
+}
 
 pub struct NgControlArgs {
     pub rx_app_state: BusReader<WorkerState>,
     pub tx_ngcontrol_state: Sender<WorkerState>,
+    pub app_args: Arguments,
     pub rx_cell_info: BusReader<MessageCellInfo>,
     pub tx_dci: Bus<MessageDci>,
 }
@@ -34,6 +38,7 @@ pub fn deploy_ngscope_controller(args: NgControlArgs) -> Result<JoinHandle<()>> 
         let _ = run(
             args.rx_app_state,
             args.tx_ngcontrol_state,
+            args.app_args,
             args.rx_cell_info,
             args.tx_dci,
         );
@@ -41,133 +46,140 @@ pub fn deploy_ngscope_controller(args: NgControlArgs) -> Result<JoinHandle<()>> 
     Ok(thread)
 }
 
-enum CheckCellUpdateError {
-    NoUpdate(BusReader<MessageCellInfo>),
-    Disconnected,
+fn send_final_state(tx_sink_state: &Sender<WorkerState>) -> Result<()> {
+    Ok(tx_sink_state.send(WorkerState::Stopped(WorkerType::CellSource))?)
+}
+
+fn wait_for_running(
+    rx_app_state: &mut BusReader<WorkerState>,
+    tx_source_state: &Sender<WorkerState>,
+) -> Result<()> {
+    match wait_until_running(rx_app_state) {
+        Ok(_) => Ok(()),
+        _ => {
+            send_final_state(tx_source_state)?;
+            Err(anyhow!("[source] Main did not send 'Running' message"))
+        }
+    }
 }
 
 fn check_cell_update(
-    mut rx_cell_info: BusReader<MessageCellInfo>,
-    ) -> Result<(CellInfo, BusReader<MessageCellInfo>), CheckCellUpdateError> {
+    rx_cell_info: &mut BusReader<MessageCellInfo>,
+) -> Result<Option<CellInfo>> {
     match rx_cell_info.try_recv() {
         Ok(msg) => {
-            Ok((msg.cell_info, rx_cell_info))
+            Ok(Some(msg.cell_info))
         },
-        Err(TryRecvError::Empty) => Err(CheckCellUpdateError::NoUpdate(rx_cell_info)),
-        Err(TryRecvError::Disconnected) => Err(CheckCellUpdateError::Disconnected),
+        Err(TryRecvError::Disconnected) => {
+            // TODO: print error properly
+            Err(anyhow!("[ngcontrol] err: rx_cell_info disconnected!"))
+        }
+        Err(TryRecvError::Empty) => { Ok(None) },
     }
 }
 
 fn run(
     mut rx_app_state: BusReader<WorkerState>,
     tx_ngcontrol_state: Sender<WorkerState>,
+    app_args: Arguments,
     mut rx_cell_info: BusReader<MessageCellInfo>,
-    _tx_dci: Bus<MessageDci>,
+    tx_dci: Bus<MessageDci>,
 ) -> Result<()> {
     tx_ngcontrol_state.send(WorkerState::Running(WorkerType::NgScopeController))?;
-    thread::sleep(Duration::from_secs(1));
+    wait_for_running(&mut rx_app_state, &tx_ngcontrol_state)?;
+
+    let mut ng_process_option: Option<Child> = None;
+    let mut ngscope_config = NgScopeConfig {
+        ..Default::default()
+    };
+
+    let (tx_dci_thread, rx_dci_thread) = channel::<LocalDciState>();
+    let dci_thread = deploy_dci_fetcher_thread(
+        rx_dci_thread,
+        tx_dci,
+    )?;
+
+    let mut ngcontrol_state: NgControlState = NgControlState::CheckingInitialCellInfo;
 
     loop {
         /* <precheck> */
         thread::sleep(Duration::from_millis(DEFAULT_WORKER_SLEEP_MS));
-        match check_not_stopped(rx_app_state) {
-            Ok(rx_app) => rx_app_state = rx_app,
-            _ => break,
+        if check_not_stopped(&mut rx_app_state).is_err() {
+            break;
         }
         /* </precheck> */
 
-        match check_cell_update(rx_cell_info) {
-            Ok((cell_info, returnal)) => {
-                println!("[ngcontrol] cell_info: {:#?}", cell_info);
-                rx_cell_info = returnal;
+        match ngcontrol_state {
+            NgControlState::CheckingInitialCellInfo => {
+                if let Some(cell_info) = check_cell_update(&mut rx_cell_info)? {
+                    println!("[ngcontrol] cell_info: {:#?}", cell_info);
+                    ngscope_config.rf_config0.as_mut().unwrap().rf_freq = cell_info.cells.first().unwrap().frequency;
+                    ng_process_option = Some(start_ngscope(&ngscope_config)?);
+                    ngcontrol_state = NgControlState::CheckingCellInfo;
+                }
             },
-            Err(CheckCellUpdateError::NoUpdate(returnal)) => {
-                rx_cell_info = returnal;
+            NgControlState::CheckingCellInfo => {
+                if let Some(cell_info) = check_cell_update(&mut rx_cell_info)? {
+                    println!("[ngcontrol] cell_info: {:#?}", cell_info);
+                    ngscope_config.rf_config0.as_mut().unwrap().rf_freq = cell_info.cells.first().unwrap().frequency;
+                    ng_process_option = match ng_process_option {
+                        Some(process) => { Some(restart_ngscope(process, &ngscope_config)?) },
+                        None => { Some(start_ngscope(&ngscope_config)?) },
+                    };
+                    ngcontrol_state = NgControlState::CheckingCellInfo;
+                }
             },
-            Err(CheckCellUpdateError::Disconnected) => {
-                // TODO: print error properly
-                println!("[ngcontrol] err: rx_cell_info disconnected!");
-                break;
-            },
+            _ => {},
         }
-        // TODO: Check for new CellInfo -> set ngscope to new frequency
-        // TODO: Forward ngsocpe dci messages to tx_dci
     }
 
+    send_explicit_state(&tx_ngcontrol_state,
+                        ExplicitWorkerState::NgControl(
+                            NgControlState::StoppingDciFetcherThread)
+                        )?;
+    tx_dci_thread.send(LocalDciState::Stop)?;
+    let _ = dci_thread.join();
+    if let Some(process) = ng_process_option {
+        send_explicit_state(&tx_ngcontrol_state,
+                            ExplicitWorkerState::NgControl(
+                                NgControlState::StoppingNgScopeProcess)
+                            )?;
+        stop_ngscope(process)?;
+    }
     tx_ngcontrol_state.send(WorkerState::Stopped(WorkerType::NgScopeController))?;
     Ok(())
 }
 
-#[allow(dead_code)]
-fn start_continuous_tracking(args: Arguments) -> Result<()> {
-    // Retrieve cell information
-    // Write config
-    // Start ng-scope process
-    // loop:
-    //   Retrieve cell (did it change?)
-    //   Update config
-    //   Restart ng-scope process
-    //   -> implement hysterese: only restart if it has been running for a while.
-
-    let sigint: Arc<AtomicBool> = util::prepare_sigint_notifier()?;
-    let milesight_args: MilesightArgs = args.milesight.unwrap();
-    let cell_info: CellInfo = CellInfo::from_milesight_router(
-        &milesight_args.clone().milesight_address.unwrap(),
-        &milesight_args.clone().milesight_user.unwrap(),
-        &milesight_args.clone().milesight_auth.unwrap(),
-    )?;
-    let mut single_cell = cell_info.cells.first().unwrap().clone();
-    let mut ngscope_process: Child;
-    let mut ngscope_config = NgScopeConfig {
-        rnti: 0xFFFF,
-        ..Default::default()
-    };
-
-    ngscope_config.rf_config0.as_mut().unwrap().rf_freq = single_cell.frequency;
-    ngscope_process = start_ngscope(&ngscope_config)?;
-
-    while !util::is_notifier(&sigint) {
-        let latest_cell_info: CellInfo = CellInfo::from_milesight_router(
-            &milesight_args.clone().milesight_address.unwrap(),
-            &milesight_args.clone().milesight_user.unwrap(),
-            &milesight_args.clone().milesight_auth.unwrap(),
-        )?;
-        let latest_single_cell = latest_cell_info.cells.first().unwrap();
-        if latest_single_cell.cell_id != single_cell.cell_id {
-            // TODO: Determine the RNIT using RNTI matching
-            ngscope_config.rnti = 0xFFFF;
-            ngscope_config.rf_config0.as_mut().unwrap().rf_freq = latest_single_cell.frequency;
-            ngscope_process = restart_ngscope(ngscope_process, &ngscope_config)?;
-            single_cell = latest_single_cell.clone();
-        }
-        thread::sleep(Duration::from_secs(10));
-    }
-    stop_ngscope(ngscope_process)?;
-    Ok(())
+fn deploy_dci_fetcher_thread(
+    rx_local_dci_state: Receiver<LocalDciState>,
+    tx_dci: Bus<MessageDci>,
+) -> Result<JoinHandle<()>> {
+    let thread = thread::spawn(move || {
+        let _ = run_dci_fetcher(
+            rx_local_dci_state,
+            tx_dci
+        );
+    });
+    Ok(thread)
 }
 
-#[allow(dead_code)]
-fn init_dci_server(local_addr: &str, server_addr: &str) -> Result<UdpSocket> {
-    let socket = UdpSocket::bind(local_addr).unwrap();
-    ngscope::ngscope_validate_server(&socket, server_addr).expect("server validation error");
-
-    Ok(socket)
-}
-
-#[allow(dead_code)]
-fn start_listen_for_ngscope_message() -> Result<()> {
+fn run_dci_fetcher(
+    rx_local_dci_state: Receiver<LocalDciState>,
+    mut tx_dci: Bus<MessageDci>,
+) -> Result<()> {
+    // TODO: pass ngscope addr:port information
     let local_addr = "0.0.0.0:8888";
     let server_addr = "0.0.0.0:6767";
-
     let socket = init_dci_server(local_addr, server_addr)?;
-
-    println!("Successfully initialized Dci server");
-    println!("Analyzing incoming messages..");
-
     loop {
+        thread::sleep(Duration::from_millis(DEFAULT_WORKER_SLEEP_MS));
+        match local_dci_check_not_stopped(&rx_local_dci_state) {
+            Ok(_) => {},
+            _ => break,
+        }
+
         if let Ok(msg) = ngscope::ngscope_recv_single_message(&socket) {
             match msg {
-                Message::Start => {}
                 Message::CellDci(cell_dci) => {
                     println!(
                         "<THESIS> {:?} | {:03?} | {:03?} | {:08?} | {:08?} | {:03?} | {:03?}",
@@ -179,20 +191,47 @@ fn start_listen_for_ngscope_message() -> Result<()> {
                         cell_dci.total_dl_reTx,
                         cell_dci.total_ul_reTx
                     );
+
+                    tx_dci.broadcast(MessageDci { ngscope_dci: *cell_dci });
                 }
                 Message::Dci(ue_dci) => {
+                    // TODO: Evaluate how to handle this
                     println!("{:?}", ue_dci)
                 }
                 Message::Config(cell_config) => {
+                    // TODO: Evaluate how to handle this
                     println!("{:?}", cell_config)
                 }
-                Message::Exit => {
-                    break;
-                }
+                // TODO: Evaluate how to handle Start andExit
+                Message::Start => {}
+                Message::Exit => {}
             }
         } else {
+            // TODO: print error properly
             println!("could not receive message..")
         }
     }
     Ok(())
 }
+
+fn local_dci_check_not_stopped(
+    rx_local_dci_state: &Receiver<LocalDciState>,
+) -> Result<()> {
+    match rx_local_dci_state.try_recv() {
+        Ok(msg) => match msg {
+            LocalDciState::Stop => Err(anyhow!("[ngcontrol.local_dci_fetcher] received stop")),
+            // _ => Ok(()), <- use this if LocalDciState gets more fields
+        },
+        Err(TryRecvError::Empty) => Ok(()),
+        Err(TryRecvError::Disconnected) => Err(anyhow!("[ngcontrol.local_dci_fetcher] rx_local_dci_state disconnected")),
+    }
+}
+
+#[allow(dead_code)]
+fn init_dci_server(local_addr: &str, server_addr: &str) -> Result<UdpSocket> {
+    let socket = UdpSocket::bind(local_addr).unwrap();
+    ngscope::ngscope_validate_server(&socket, server_addr).expect("server validation error");
+
+    Ok(socket)
+}
+

--- a/src/logic/rnti_matcher.rs
+++ b/src/logic/rnti_matcher.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use bus::{Bus, BusReader};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::SyncSender;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -12,7 +12,7 @@ use crate::logic::{
 
 pub struct RntiMatcherArgs {
     pub rx_app_state: BusReader<WorkerState>,
-    pub tx_rntimatcher_state: Sender<WorkerState>,
+    pub tx_rntimatcher_state: SyncSender<WorkerState>,
     pub rx_dci: BusReader<MessageDci>,
     pub tx_rnti: Bus<MessageRnti>,
 }
@@ -29,13 +29,13 @@ pub fn deploy_rnti_matcher(args: RntiMatcherArgs) -> Result<JoinHandle<()>> {
     Ok(thread)
 }
 
-fn send_final_state(tx_rntimatcher_state: &Sender<WorkerState>) -> Result<()> {
+fn send_final_state(tx_rntimatcher_state: &SyncSender<WorkerState>) -> Result<()> {
     Ok(tx_rntimatcher_state.send(WorkerState::Stopped(WorkerType::RntiMatcher))?)
 }
 
 fn wait_for_running(
     rx_app_state: &mut BusReader<WorkerState>,
-    tx_rntimtacher_state: &Sender<WorkerState>,
+    tx_rntimtacher_state: &SyncSender<WorkerState>,
 ) -> Result<()> {
     match wait_until_running(rx_app_state) {
         Ok(_) => Ok(()),
@@ -48,7 +48,7 @@ fn wait_for_running(
 
 fn run(
     mut rx_app_state: BusReader<WorkerState>,
-    tx_rntimatcher_state: Sender<WorkerState>,
+    tx_rntimatcher_state: SyncSender<WorkerState>,
     _rx_dci: BusReader<MessageDci>,
     _tx_rnti: Bus<MessageRnti>,
 ) -> Result<()> {

--- a/src/ngscope/config.rs
+++ b/src/ngscope/config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::option::Option;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[allow(non_snake_case)]
 pub struct NgScopeConfigRfDev {
     pub rf_freq: u64,
@@ -19,7 +19,7 @@ pub struct NgScopeConfigRfDev {
     pub log_phich: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct NgScopeConfigDciLog {
     pub nof_cell: u16,
     pub log_ul: bool,
@@ -27,7 +27,7 @@ pub struct NgScopeConfigDciLog {
     pub log_interval: u16,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct NgScopeConfig {
     pub nof_rf_dev: u16,
     pub rnti: u16,
@@ -62,7 +62,7 @@ impl Default for NgScopeConfigRfDev {
             N_id_2: -1,
             rf_args: "serial=3295B62".to_string(),
             nof_thread: 4,
-            disable_plot: None,
+            disable_plot: Some(true),
             log_dl: None,
             log_ul: None,
             log_phich: None,
@@ -186,6 +186,7 @@ rf_config0 = {
     N_id_2 = -1;
     rf_args = "serial=3295B62";
     nof_thread = 4;
+    disable_plot = true;
 };"#;
 
     #[test]


### PR DESCRIPTION
### Cleanup

* Add constants for channel/bus sizes
* Replace pass and return mutables with passing mutable borrows
* WiP: Implement ngcontrol
  * Start separate dci_fetcher thread
  * Add stateful ngcontrol thread design
  
### Implement NgScopeController worker

* Add dci_fetcher thread to NgScopeController
* Switch channel type to sync_channel for all inter-thread communication
* Improve check_not_stopped with .is_err() syntax
* Add parse arguments for ngscope parameters
* Make ngscope implementations non-blocking
  