### PR TITLE
Implement CellRntiRingBuffer and fix sending delay

### DIFF
--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -184,6 +184,8 @@ impl RntiMatcherState {
 #[derive(Clone, Debug, PartialEq)]
 pub enum RntiMatchingErrorType {
     ExceededDciTimestampDelta,
+    ErrorGeneratingTrafficPatternFeatures,
+    ErrorFindingBestMatchingRnti,
 }
 
 impl WorkerState for RntiMatcherState {
@@ -250,7 +252,7 @@ pub struct MessageCellInfo {
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct MessageRnti {
     /* cell_id -> ue_rnti */
-    cell_rnti: HashMap<u64, (u16, f64)>,
+    cell_rnti: HashMap<u64, u16>,
 }
 
 /*  --------------  */

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod logic;
 mod ngscope;
 mod parse;
 mod util;
+mod math_util;
 
 use logic::cell_sink::{deploy_cell_sink, CellSinkArgs};
 use logic::cell_source::{deploy_cell_source, CellSourceArgs};

--- a/src/math_util.rs
+++ b/src/math_util.rs
@@ -1,0 +1,134 @@
+
+use anyhow::{anyhow, Result};
+use nalgebra::{DVector, DMatrix};
+
+
+/* Feature Matching */
+
+pub fn calculate_mean_variance(list: &[f64]) -> Result<(f64, f64)> {
+    let total_packets = list.len() as f64;
+
+    if total_packets <= 0.0 {
+        return Err(anyhow!("Cannot determine mean/variance of 0 length array"));
+    }
+
+    let mean = list.iter().sum::<f64>() / total_packets;
+
+    let variance = list
+        .iter()
+        .map(|&item| {
+            let diff = item - mean;
+            diff * diff
+        })
+        .sum::<f64>()
+        / total_packets;
+
+    Ok((mean, variance))
+}
+
+pub fn calculate_median(list: &[f64]) -> Result<f64> {
+    let len: usize = list.len();
+    if len == 0 {
+        return Err(anyhow!("Cannot determine median of 0 length array"));
+    }
+    let mut sorted_list: Vec<f64> = list.to_vec();
+    sorted_list.sort_by(|a, b| a.partial_cmp(b).unwrap()); // Handle NaN values safely
+    if len % 2 == 0 {
+        // If the length is even, return the average of the two middle elements
+        let mid1 = sorted_list[len / 2 - 1];
+        let mid2 = sorted_list[len / 2];
+        Ok((mid1 + mid2) * 0.5)
+    } else {
+        // If the length is odd, return the middle element
+        Ok(sorted_list[len / 2])
+    }
+}
+
+#[allow(dead_code)]
+pub fn calculate_weighted_manhattan_distance(
+    vec_a: &[f64],
+    vec_b: &[f64],
+    weightings: &[f64],
+) -> f64 {
+    assert_eq!(
+        vec_a.len(),
+        vec_b.len(),
+        "Calcuting Euclidean distance: Vectors must have the same length"
+    );
+    assert_eq!(
+        vec_a.len(),
+        weightings.len(),
+        "Calcuting Euclidean distance: Vectors and weightings must have the same length"
+    );
+
+    vec_a
+        .iter()
+        .zip(vec_b.iter())
+        .zip(weightings.iter())
+        .fold(0.0, |acc, ((&a, &b), &w)| acc + w * (a - b).abs())
+}
+
+pub fn calculate_weighted_euclidean_distance(
+    vec_a: &[f64],
+    vec_b: &[f64],
+    weightings: &[f64],
+) -> f64 {
+    assert_eq!(
+        vec_a.len(),
+        vec_b.len(),
+        "Calcuting Euclidean distance: Vectors must have the same length"
+    );
+    assert_eq!(
+        vec_a.len(),
+        weightings.len(),
+        "Calcuting Euclidean distance: Vectors and weightings must have the same length"
+    );
+
+    let sum_of_squared_diff: f64 = vec_a
+        .iter()
+        .zip(vec_b.iter())
+        .zip(weightings.iter())
+        .map(|((&a, &b), &w)| w * (a - b).powi(2))
+        .sum();
+
+    sum_of_squared_diff.sqrt()
+}
+
+#[allow(dead_code)]
+pub fn calculate_weighted_manhattan_distance_matrix(
+    matr_a: &DMatrix<f64>,
+    matr_b: &DMatrix<f64>,
+    weightings: &DVector<f64>,
+) -> DVector<f64> {
+    assert_eq!(
+        (matr_a.nrows(), matr_a.ncols()),
+        (matr_b.nrows(), matr_b.ncols()),
+        "Calcuting Euclidean distance: Matrices must have the same dimensions"
+    );
+    let diff_matrix = (matr_a - matr_b).abs();
+    diff_matrix * weightings
+}
+
+pub fn calculate_weighted_euclidean_distance_matrix(
+    matr_a: &DMatrix<f64>,
+    matr_b: &DMatrix<f64>,
+    weightings: &DVector<f64>,
+) -> DVector<f64> {
+    assert_eq!(
+        (matr_a.nrows(), matr_a.ncols()),
+        (matr_b.nrows(), matr_b.ncols()),
+        "Calcuting Euclidean distance: Matrices must have the same dimensions"
+    );
+    let diff_matrix = matr_a - matr_b;
+    let weighted_squared_diff_vector = diff_matrix.component_mul(&diff_matrix) * weightings;
+
+    weighted_squared_diff_vector.map(|x| x.sqrt())
+}
+
+pub fn standardize_feature_vec(feature_vec: &[f64], std_vec: &[(f64, f64)]) -> Vec<f64> {
+    feature_vec
+        .iter()
+        .zip(std_vec.iter())
+        .map(|(&feature, &(mean, std_deviation))| (feature - mean) / std_deviation)
+        .collect()
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,15 +1,87 @@
 #![allow(dead_code)]
 
-use anyhow::{anyhow, Result};
-use casual_logger::{Level, Log};
-use lazy_static::lazy_static;
-use nalgebra::{DMatrix, DVector};
+use std::hash::Hash;
+use std::collections::{VecDeque, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use anyhow::{anyhow, Result};
+use casual_logger::{Level, Log};
+use lazy_static::lazy_static;
 
 use crate::logic::rnti_matcher::TrafficCollection;
+
+#[derive(Clone, Debug, Default)]
+pub struct RingBuffer<T> {
+    buffer: VecDeque<T>,
+    size: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CellRntiRingBuffer {
+    cell_buffers: HashMap<u64, RingBuffer<u16>>,
+    size: usize,
+}
+
+impl<T> RingBuffer<T> 
+where
+    T: Eq + Hash + Clone,
+{
+    pub fn new(size: usize) -> Self {
+        RingBuffer {
+            buffer: VecDeque::with_capacity(size),
+            size,
+        }
+    }
+
+    pub fn add(&mut self, value: T) {
+        if self.buffer.len() == self.size {
+            self.buffer.pop_front(); // Remove the oldest value if the buffer is full
+        }
+        self.buffer.push_back(value); // Add the new value
+    }
+
+    pub fn most_frequent(&self) -> Option<T> {
+        let mut frequency_map = std::collections::HashMap::new();
+        for value in self.buffer.iter() {
+            *frequency_map.entry(value).or_insert(0) += 1;
+        }
+        frequency_map
+            .into_iter()
+            .max_by_key(|&(_, count)| count)
+            .map(|(value, _)| value.clone())
+    }
+}
+
+impl CellRntiRingBuffer {
+    pub fn new(size: usize) -> CellRntiRingBuffer {
+        CellRntiRingBuffer {
+            size,
+            cell_buffers: HashMap::new(),
+        }
+    }
+
+    pub fn update(&mut self, cell_rntis: &HashMap<u64, u16>) {
+        for (&cell, &rnti) in cell_rntis.iter() {
+            let cell_buffer = self.cell_buffers
+                .entry(cell)
+                .or_insert_with(|| RingBuffer::new(self.size));
+            cell_buffer.add(rnti);
+        }
+    }
+
+    pub fn most_frequent(&self) -> HashMap<u64, u16> {
+        let mut cell_rntis: HashMap<u64, u16> = HashMap::new();
+        for (&cell, cell_buffer) in self.cell_buffers.iter() {
+            if let Some(most_frequent_rnti) = cell_buffer.most_frequent() {
+                cell_rntis.insert(cell, most_frequent_rnti);
+            }
+        }
+        cell_rntis
+    }
+}
+
 
 pub fn prepare_sigint_notifier() -> Result<Arc<AtomicBool>> {
     let notifier = Arc::new(AtomicBool::new(false));
@@ -122,127 +194,4 @@ pub fn is_debug() -> bool {
     IS_DEBUG.load(Ordering::SeqCst)
 }
 
-/* Feature Matching */
 
-pub fn calculate_mean_variance(list: &[f64]) -> (f64, f64) {
-    let total_packets = list.len() as f64;
-
-    if total_packets == 0.0 {
-        return (0.0, 0.0);
-    }
-
-    let mean = list.iter().sum::<f64>() / total_packets;
-
-    let variance = list
-        .iter()
-        .map(|&item| {
-            let diff = item - mean;
-            diff * diff
-        })
-        .sum::<f64>()
-        / total_packets;
-
-    (mean, variance)
-}
-
-pub fn calculate_median(list: &[f64]) -> f64 {
-    let mut sorted_list: Vec<f64> = list.to_vec();
-    sorted_list.sort_by(|a, b| a.partial_cmp(b).unwrap()); // Handle NaN values safely
-    let len = sorted_list.len();
-    if len % 2 == 0 {
-        // If the length is even, return the average of the two middle elements
-        let mid1 = sorted_list[len / 2 - 1];
-        let mid2 = sorted_list[len / 2];
-        (mid1 + mid2) * 0.5
-    } else {
-        // If the length is odd, return the middle element
-        sorted_list[len / 2]
-    }
-}
-
-pub fn calculate_weighted_manhattan_distance(
-    vec_a: &[f64],
-    vec_b: &[f64],
-    weightings: &[f64],
-) -> f64 {
-    assert_eq!(
-        vec_a.len(),
-        vec_b.len(),
-        "Calcuting Euclidean distance: Vectors must have the same length"
-    );
-    assert_eq!(
-        vec_a.len(),
-        weightings.len(),
-        "Calcuting Euclidean distance: Vectors and weightings must have the same length"
-    );
-
-    vec_a
-        .iter()
-        .zip(vec_b.iter())
-        .zip(weightings.iter())
-        .fold(0.0, |acc, ((&a, &b), &w)| acc + w * (a - b).abs())
-}
-
-pub fn calculate_weighted_euclidean_distance(
-    vec_a: &[f64],
-    vec_b: &[f64],
-    weightings: &[f64],
-) -> f64 {
-    assert_eq!(
-        vec_a.len(),
-        vec_b.len(),
-        "Calcuting Euclidean distance: Vectors must have the same length"
-    );
-    assert_eq!(
-        vec_a.len(),
-        weightings.len(),
-        "Calcuting Euclidean distance: Vectors and weightings must have the same length"
-    );
-
-    let sum_of_squared_diff: f64 = vec_a
-        .iter()
-        .zip(vec_b.iter())
-        .zip(weightings.iter())
-        .map(|((&a, &b), &w)| w * (a - b).powi(2))
-        .sum();
-
-    sum_of_squared_diff.sqrt()
-}
-
-pub fn calculate_weighted_manhattan_distance_matrix(
-    matr_a: &DMatrix<f64>,
-    matr_b: &DMatrix<f64>,
-    weightings: &DVector<f64>,
-) -> DVector<f64> {
-    assert_eq!(
-        (matr_a.nrows(), matr_a.ncols()),
-        (matr_b.nrows(), matr_b.ncols()),
-        "Calcuting Euclidean distance: Matrices must have the same dimensions"
-    );
-    let diff_matrix = (matr_a - matr_b).abs();
-    diff_matrix * weightings
-}
-
-pub fn calculate_weighted_euclidean_distance_matrix(
-    matr_a: &DMatrix<f64>,
-    matr_b: &DMatrix<f64>,
-    weightings: &DVector<f64>,
-) -> DVector<f64> {
-    assert_eq!(
-        (matr_a.nrows(), matr_a.ncols()),
-        (matr_b.nrows(), matr_b.ncols()),
-        "Calcuting Euclidean distance: Matrices must have the same dimensions"
-    );
-    let diff_matrix = matr_a - matr_b;
-    let weighted_squared_diff_vector = diff_matrix.component_mul(&diff_matrix) * weightings;
-
-    weighted_squared_diff_vector.map(|x| x.sqrt())
-}
-
-pub fn standardize_feature_vec(feature_vec: &[f64], std_vec: &[(f64, f64)]) -> Vec<f64> {
-    feature_vec
-        .iter()
-        .zip(std_vec.iter())
-        .map(|(&feature, &(mean, std_deviation))| (feature - mean) / std_deviation)
-        .collect()
-}


### PR DESCRIPTION
* Add RingBuffer to count most frequent RNTIs over mutliple iterations
* Move mathematic utilitites from util to new module math_util
* Add MatchingErrorHandling -> Reset traffic generator on matching error -> Make math functions return Result<>

Debug CPU usage of rntimatcher.gen thread:

  In the traffic_generator thread, the TrafficPattern was in every sending iteration (a) cloned and (b) wrapped into a new Box instance which lead to high frequent memory allocation. This induced a high delay on the traffic pattern sending and high CPU usage of ~80% for the traffic_generator thread. With this fix, the sending rate for pattern A increased from ~800 Kbit/s to ~12 Mbit/s!!!