### PR TITLE
Change traffic_pattern_type argument to list of types

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -124,7 +124,7 @@ pub struct RntiMatchingArgs {
 
     /// Define which traffic pattern to use to fetch cell data
     #[arg(long, value_enum, required = false)]
-    pub matching_traffic_pattern: Option<RntiMatchingTrafficPatternType>,
+    pub matching_traffic_pattern: Option<Vec<RntiMatchingTrafficPatternType>>,
 
     /// The destination address which the traffic pattern is sent to
     #[arg(long, required = false)]
@@ -134,7 +134,7 @@ pub struct RntiMatchingArgs {
 #[derive(Clone, Debug)]
 pub struct FlattenedRntiMatchingArgs {
     pub matching_local_addr: String,
-    pub matching_traffic_pattern: RntiMatchingTrafficPatternType,
+    pub matching_traffic_pattern: Vec<RntiMatchingTrafficPatternType>,
     pub matching_traffic_destination: String,
 }
 
@@ -161,7 +161,7 @@ impl default::Default for Arguments {
             }),
             rntimatching: Some(RntiMatchingArgs {
                 matching_local_addr: Some("0.0.0.0:9292".to_string()),
-                matching_traffic_pattern: Some(RntiMatchingTrafficPatternType::A),
+                matching_traffic_pattern: Some(vec![RntiMatchingTrafficPatternType::A]),
                 matching_traffic_destination: Some("1.1.1.1:53".to_string()),
             }),
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,6 +12,11 @@ use lazy_static::lazy_static;
 
 use crate::logic::rnti_matcher::TrafficCollection;
 
+
+pub const MATCHING_LOG_FILE_PREFIX: &str = "./.logs/rnti_matching_pattern_";
+pub const MATCHING_LOG_FILE_SUFFIX: &str = ".jsonl";
+
+
 #[derive(Clone, Debug, Default)]
 pub struct RingBuffer<T> {
     buffer: VecDeque<T>,
@@ -164,19 +169,24 @@ impl LogExt for Log {
 }
 
 pub fn log_rnti_matching_traffic(
-    file_path: &str,
     traffic_collection: &TrafficCollection,
 ) -> Result<()> {
+
+    let matching_log_file_path = &format!(
+        "{}{:?}{}",
+        MATCHING_LOG_FILE_PREFIX, traffic_collection.traffic_pattern_features.pattern_type, MATCHING_LOG_FILE_SUFFIX
+    );
+
     print_debug(&format!(
         "DEBUG [rntimatcher] going to write traffic to file: {:?}",
-        file_path
+        matching_log_file_path
     ));
     let json_string = serde_json::to_string(traffic_collection)?;
 
     let mut file: File = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(file_path)?;
+        .open(matching_log_file_path)?;
     writeln!(file, "{}", json_string)?;
 
     Ok(())


### PR DESCRIPTION
Instead of passing a single traffic pattern type, one shall now pass a list of pattern types which are then iterated one by one.

This allows the user to iterate serveral patterns and collect data without the need to restart the process