### PR TITLE
Send metric to matching address

### DIFF
--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -256,9 +256,21 @@ pub struct MessageRnti {
     cell_rnti: HashMap<u64, u16>,
 }
 
+/* Wrapping messages */
 #[allow(dead_code)]
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MessageMetric {
+    metric: MetricTypes,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MetricTypes {
+    A(MetricA),
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MetricA {
     /// Timestamp when the metric was calculated (not sent!)
     timestamp_us: u64,
     /// Fair share send rate [bits/subframe] = [bits/ms]

--- a/src/logic/model_handler.rs
+++ b/src/logic/model_handler.rs
@@ -12,6 +12,8 @@ use crate::logic::{
 };
 use crate::util::determine_process_id;
 
+use super::{MetricA, MetricTypes};
+
 pub struct ModelHandlerArgs {
     pub rx_app_state: BusReader<MainState>,
     pub tx_model_state: SyncSender<ModelState>,
@@ -58,7 +60,7 @@ fn run(
     rx_cell_info: &mut BusReader<MessageCellInfo>,
     rx_dci: &mut BusReader<MessageDci>,
     rx_rnti: &mut BusReader<MessageRnti>,
-    _tx_metric: &mut Bus<MessageMetric>,
+    tx_metric: &mut Bus<MessageMetric>,
 ) -> Result<()> {
     tx_model_state.send(ModelState::Running)?;
     wait_for_running(&mut rx_app_state, &tx_model_state)?;
@@ -99,8 +101,18 @@ fn run(
             }
         }
 
-        // TODO: -> Send combined message to some remote
-        //   tx_metrc.send(metrics)
+        /* Test sending data */
+        tx_metric.broadcast(MessageMetric {
+            metric: MetricTypes::A(MetricA {
+                timestamp_us: 121,
+                fair_share_send_rate: 121231,
+            })
+        });
+        // TODO: Implement sending metric
+        //   * Send combined message to remote properly
+        //   * Add input parameter to choose metric type and sending interval (or more like a "how
+        //   many subframes shall I use)
+
     }
 
     send_final_state(&tx_model_state)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use bus::Bus;
+use bus::{Bus, BusReader};
 use casual_logger::{Level, Log};
 use std::collections::HashSet;
 use std::error::Error;
@@ -61,7 +61,8 @@ fn deploy_app(
     let mut tx_dci: Bus<MessageDci> = Bus::<MessageDci>::new(BUS_SIZE_DCI);
     let mut tx_cell_info: Bus<MessageCellInfo> = Bus::<MessageCellInfo>::new(BUS_SIZE_CELL_INFO);
     let mut tx_rnti: Bus<MessageRnti> = Bus::<MessageRnti>::new(BUS_SIZE_RNTI);
-    let tx_metric: Bus<MessageMetric> = Bus::<MessageMetric>::new(BUS_SIZE_METRIC);
+    let mut tx_metric: Bus<MessageMetric> = Bus::<MessageMetric>::new(BUS_SIZE_METRIC);
+    let rx_metric: BusReader<MessageMetric> = tx_metric.add_rx();
 
     let model_args = ModelHandlerArgs {
         rx_app_state: tx_app_state.add_rx(),
@@ -77,6 +78,7 @@ fn deploy_app(
         app_args: app_args.clone(),
         rx_dci: tx_dci.add_rx(),
         tx_rnti,
+        rx_metric,
     };
     let ngcontrol_args = NgControlArgs {
         rx_app_state: tx_app_state.add_rx(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -122,13 +122,17 @@ pub struct RntiMatchingArgs {
     #[arg(long, required = false)]
     pub matching_local_addr: Option<String>,
 
-    /// Define which traffic pattern to use to fetch cell data
+    /// List of traffic patterns (iterates all given patterns)
     #[arg(long, value_enum, required = false)]
     pub matching_traffic_pattern: Option<Vec<RntiMatchingTrafficPatternType>>,
 
     /// The destination address which the traffic pattern is sent to
     #[arg(long, required = false)]
     pub matching_traffic_destination: Option<String>,
+
+    /// Log traffic used for matching (in ./logs/rnti_matching*.jsonl)
+    #[arg(long, required = false)]
+    pub matching_log_traffic: Option<bool>,
 }
 
 #[derive(Clone, Debug)]
@@ -136,6 +140,7 @@ pub struct FlattenedRntiMatchingArgs {
     pub matching_local_addr: String,
     pub matching_traffic_pattern: Vec<RntiMatchingTrafficPatternType>,
     pub matching_traffic_destination: String,
+    pub matching_log_traffic: bool,
 }
 
 impl default::Default for Arguments {
@@ -163,6 +168,7 @@ impl default::Default for Arguments {
                 matching_local_addr: Some("0.0.0.0:9292".to_string()),
                 matching_traffic_pattern: Some(vec![RntiMatchingTrafficPatternType::A]),
                 matching_traffic_destination: Some("1.1.1.1:53".to_string()),
+                matching_log_traffic: Some(true),
             }),
         }
     }
@@ -270,6 +276,7 @@ impl FlattenedRntiMatchingArgs {
             matching_local_addr: rnti_args.matching_local_addr.unwrap(),
             matching_traffic_pattern: rnti_args.matching_traffic_pattern.unwrap(),
             matching_traffic_destination: rnti_args.matching_traffic_destination.unwrap(),
+            matching_log_traffic: rnti_args.matching_log_traffic.unwrap(),
         })
     }
 }


### PR DESCRIPTION
Use [rntimatcher.gen] thread to send [model]-computed metrics to the same address as the traffic pattern is sent to.

* Add Matching parameter: matching_log_traffic<bool>
* Add MetricTypes::A and MetricA struct
* Add metric header definition
* Pass reader for metric updates to [rntimatcher.gen]