### PR TITLE
Fix NG-Scope TBS unit and update remote interface

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -397,15 +397,13 @@ fn create_rnti_fields() -> Fields {
     Fields::from(vec![
         Field::new("rnti", DataType::UInt16, true),
 
+        Field::new("dl_tbs_bit", DataType::UInt32, true),
         Field::new("dl_prb", DataType::UInt8, true),
-        Field::new("dl_tbs", DataType::UInt32, true),
-        Field::new("dl_retx", DataType::UInt8, true),
-        Field::new("dl_reserved_mcs_prb", DataType::UInt8, true),
+        Field::new("dl_no_tbs_prb", DataType::UInt8, true),
 
+        Field::new("ul_tbs_bit", DataType::UInt32, true),
         Field::new("ul_prb", DataType::UInt8, true),
-        Field::new("ul_tbs", DataType::UInt32, true),
-        Field::new("ul_retx", DataType::UInt8, true),
-        Field::new("ul_reserved_mcs_prb", DataType::UInt8, true),
+        Field::new("ul_no_tbs_prb", DataType::UInt8, true),
     ])
 }
 
@@ -437,8 +435,7 @@ fn write_arrow_ipc(
             rnti_list_builder.append(false); // Append null for an empty list
         } else {
             let rnti_struct_builder = rnti_list_builder.values();
-            append_rnti_list_to_struct(rnti_struct_builder, &cell_dci.rnti_list[0..cell_dci.nof_rnti as usize]);
-            rnti_list_builder.append(true);
+            append_rnti_list_to_struct(rnti_struct_builder, &cell_dci.rnti_list[0..cell_dci.nof_rnti as usize]); rnti_list_builder.append(true);
         }
     }
 
@@ -462,15 +459,13 @@ fn append_rnti_list_to_struct(rnti_struct_builder: &mut StructBuilder, rnti_list
     for rnti_dci in rnti_list.iter() {
         rnti_struct_builder.field_builder::<UInt16Builder>(0).unwrap().append_value(rnti_dci.rnti);
 
-        rnti_struct_builder.field_builder::<UInt8Builder>(1).unwrap().append_value(rnti_dci.dl_prb);
-        rnti_struct_builder.field_builder::<UInt32Builder>(2).unwrap().append_value(rnti_dci.dl_tbs);
-        rnti_struct_builder.field_builder::<UInt8Builder>(3).unwrap().append_value(rnti_dci.dl_reTx);
-        rnti_struct_builder.field_builder::<UInt8Builder>(4).unwrap().append_value(rnti_dci.dl_reserved_mcs_prb);
+        rnti_struct_builder.field_builder::<UInt32Builder>(1).unwrap().append_value(rnti_dci.dl_tbs_bit);
+        rnti_struct_builder.field_builder::<UInt8Builder>(2).unwrap().append_value(rnti_dci.dl_prb);
+        rnti_struct_builder.field_builder::<UInt8Builder>(3).unwrap().append_value(rnti_dci.dl_no_tbs_prb);
 
+        rnti_struct_builder.field_builder::<UInt32Builder>(4).unwrap().append_value(rnti_dci.ul_tbs_bit);
         rnti_struct_builder.field_builder::<UInt8Builder>(5).unwrap().append_value(rnti_dci.ul_prb);
-        rnti_struct_builder.field_builder::<UInt32Builder>(6).unwrap().append_value(rnti_dci.ul_tbs);
-        rnti_struct_builder.field_builder::<UInt8Builder>(7).unwrap().append_value(rnti_dci.ul_reTx);
-        rnti_struct_builder.field_builder::<UInt8Builder>(8).unwrap().append_value(rnti_dci.ul_reserved_mcs_prb);
+        rnti_struct_builder.field_builder::<UInt8Builder>(6).unwrap().append_value(rnti_dci.ul_no_tbs_prb);
 
         rnti_struct_builder.append(true);
     }

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -281,8 +281,8 @@ pub struct MetricA {
     oldest_dci_timestamp_us: u64,
     /// Number of DCIs used to calculate the metric
     nof_dci: u16,
-    /// Number of phy-layer re-transmissions
-    nof_re_tx: u16,
+    /// Ratio of no TBS PRBs to PRBs with TBS (~reTx ratio)
+    no_tbs_prb_ratio: f64,
     /// Flag, signalling whether phy_rate was averagerd over all RNTIs or just our UE RNTI
     flag_phy_rate_all_rnti: u8,
     /// Average bit per PRB (either over all RNTIs or just the UE RNTI)

--- a/src/logic/rnti_matcher.rs
+++ b/src/logic/rnti_matcher.rs
@@ -648,10 +648,10 @@ impl TrafficCollection {
 
             // Update the traffic for the specific TTI
             let traffic = ue_traffic.traffic.entry(cell_dci.time_stamp).or_default();
-            traffic.dl_bytes += rnti_dci.dl_tbs as u64;
-            traffic.ul_bytes += rnti_dci.ul_tbs as u64;
-            ue_traffic.total_dl_bytes += rnti_dci.dl_tbs as u64;
-            ue_traffic.total_ul_bytes += rnti_dci.ul_tbs as u64;
+            traffic.dl_bytes += (rnti_dci.dl_tbs_bit / 8) as u64;
+            traffic.ul_bytes += (rnti_dci.ul_tbs_bit / 8) as u64;
+            ue_traffic.total_dl_bytes += (rnti_dci.dl_tbs_bit / 8) as u64;
+            ue_traffic.total_ul_bytes += (rnti_dci.ul_tbs_bit / 8) as u64;
         }
 
         // Increment the nof_dci

--- a/src/ngscope/types.rs
+++ b/src/ngscope/types.rs
@@ -13,7 +13,7 @@ pub const NGSCOPE_MESSAGE_TYPE_SIZE: usize = 4;
 pub const NGSCOPE_MESSAGE_VERSION_POSITION: usize = 4;
 pub const NGSCOPE_MESSAGE_CONTENT_POSITION: usize = 5;
 pub const NGSCOPE_STRUCT_SIZE_DCI: usize = 40;
-pub const NGSCOPE_STRUCT_SIZE_CELL_DCI: usize = 848;
+pub const NGSCOPE_STRUCT_SIZE_CELL_DCI: usize = 856;
 pub const NGSCOPE_STRUCT_SIZE_CONFIG: usize = 12; // TODO: Determine this actually
 
 // IMPORTANT:
@@ -134,15 +134,13 @@ impl NgScopeUeDci {
 #[allow(non_snake_case)]
 pub struct NgScopeRntiDci {
     pub rnti: u16,
-    pub dl_tbs: u32,
+    pub dl_tbs_bit: u32,
     pub dl_prb: u8,
-    pub dl_reTx: u8,
-    pub dl_reserved_mcs_prb: u8,
+    pub dl_no_tbs_prb: u8,
 
-    pub ul_tbs: u32,
+    pub ul_tbs_bit: u32,
     pub ul_prb: u8,
-    pub ul_reTx: u8,
-    pub ul_reserved_mcs_prb: u8,
+    pub ul_no_tbs_prb: u8,
 }
 
 #[repr(C)]
@@ -152,14 +150,12 @@ pub struct NgScopeCellDci {
     pub cell_id: u8,
     pub time_stamp: u64,
     pub tti: u16,
-    pub total_dl_tbs: u64,
-    pub total_ul_tbs: u64,
-    pub total_dl_prb: u8,
-    pub total_ul_prb: u8,
-    pub total_dl_reTx: u8,
-    pub total_ul_reTx: u8,
-    pub total_dl_reserved_mcs_prb: u8,
-    pub total_ul_reserved_mcs_prb: u8,
+    pub total_dl_tbs_bit: u64,
+    pub total_dl_prb: u16,
+    pub total_dl_no_tbs_prb: u16,
+    pub total_ul_tbs_bit: u64,
+    pub total_ul_prb: u16,
+    pub total_ul_no_tbs_prb: u16,
     pub nof_rnti: u8,
     pub rnti_list: [NgScopeRntiDci; NGSCOPE_MAX_NOF_RNTI],
 }
@@ -170,14 +166,12 @@ impl Default for NgScopeCellDci {
             cell_id: 0,
             time_stamp: 0,
             tti: 0,
-            total_dl_tbs: 0,
-            total_ul_tbs: 0,
+            total_dl_tbs_bit: 0,
+            total_ul_tbs_bit: 0,
             total_dl_prb: 0,
             total_ul_prb: 0,
-            total_dl_reTx: 0,
-            total_ul_reTx: 0,
-            total_dl_reserved_mcs_prb: 0,
-            total_ul_reserved_mcs_prb: 0,
+            total_dl_no_tbs_prb: 0,
+            total_ul_no_tbs_prb: 0,
             nof_rnti: 0,
             rnti_list: [NgScopeRntiDci::default(); NGSCOPE_MAX_NOF_RNTI],
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,14 +125,14 @@ pub fn determine_process_id() -> u64 {
 
 pub fn print_dci(dci: crate::ngscope::types::NgScopeCellDci) {
     print_info(&format!(
-        "DEBUG: {:?} | {:03?} | {:03?} | {:08?} | {:08?} | {:03?} | {:03?}",
+        "DEBUG: {:?} | {:08?} | {:08?} | {:03?} | {:03?} | {:03?} | {:03?}",
         dci.nof_rnti,
+        dci.total_dl_tbs_bit,
+        dci.total_ul_tbs_bit,
         dci.total_dl_prb,
         dci.total_ul_prb,
-        dci.total_dl_tbs,
-        dci.total_ul_tbs,
-        dci.total_dl_reTx,
-        dci.total_ul_reTx
+        dci.total_dl_no_tbs_prb,
+        dci.total_ul_no_tbs_prb,
     ));
 }
 


### PR DESCRIPTION
* TBS was transmitted in Bits, not Bytes
* Adapt DCI logging to actual unit and new remote interface changes
* Collect dl/ul_no_tbs_prb instead of reTx and reservered_mcs
* Add not_tbs_prb_ratio to MetricResult

WiP: Start nof_rnti_share_type implementation