### PR TITLE
Fix [model] logging, c_p equation bug, and fair share type signalling

### DIFF
--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -310,6 +310,8 @@ pub struct MessageDownloadConfig {
 pub struct MetricA {
     /// Timestamp when the metric was calculated
     timestamp_us: u64,
+    /// Fair (0), less fair (1) , Greedy (2)
+    fair_share_type: u8,
     /// Fair share send rate [bits/subframe] = [bits/ms]
     fair_share_send_rate: u64,
     /// Timestamp of the latest DCI used to calculate the metric
@@ -320,10 +322,10 @@ pub struct MetricA {
     nof_dci: u16,
     /// Ratio of no TBS PRBs to PRBs with TBS (~reTx ratio)
     no_tbs_prb_ratio: f64,
-    /// Flag, signalling whether phy_rate was averagerd over all RNTIs or just our UE RNTI
-    flag_phy_rate_all_rnti: u8,
-    /// Average bit per PRB (either over all RNTIs or just the UE RNTI)
+    /// Average bit per PRB
     phy_rate: u64,
+    /// Flag, signalling whether phy_rate was static (0) averagerd over all RNTIs (1) or just our UE RNTI (2)
+    phy_rate_mode: u8,
 }
 
 /*  --------------  */

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
-use libc::{c_void, getsockopt, socklen_t, TCP_INFO};
+use libc::{c_void, getsockopt, socklen_t, TCP_INFO, gettid};
 use std::mem;
 
 use crate::logger::log_info;
@@ -158,7 +158,8 @@ pub fn helper_json_pointer(
 
 pub fn determine_process_id() -> u64 {
     /* Taken from: https://github.com/alecmocatta/palaver/blob/cc955a9d56f187fe57a2d042e4ff4120d50dc3a7/src/thread.rs#L23 */
-    match Into::<libc::pid_t>::into(nix::unistd::gettid()).try_into() {
+    let gettid_res = unsafe { gettid() };
+    match Into::<libc::pid_t>::into(gettid_res).try_into() {
         Ok(res) => res,
         Err(_) => std::process::id() as u64,
     }


### PR DESCRIPTION
* Add a timestamp_us to LogMetric of [model]
* Remove double p_all_rnti from c_p equation
* Publish fair share type on download-start from [downloader] to [model]