### PR TITLE
fix cli args causing null values in config

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -197,10 +197,6 @@ pub struct NgScopeArgs {
     /// Determine the number of DCIs contained in a single log file
     #[arg(long, required = false)]
     pub ng_log_dci_batch_size: Option<u64>,
-
-    /// rf_args such as setting serial (allowing configuration of which SDR to use)
-    #[arg(long, required = false)]
-    pub ng_rf_args: Option<String>,
 }
 
 //why is only one of the strings optional?
@@ -213,7 +209,6 @@ pub struct FlattenedNgScopeArgs {
     pub ng_start_process: bool,
     pub ng_log_dci: bool,
     pub ng_log_dci_batch_size: u64,
-    pub ng_rf_args: String,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -536,9 +531,6 @@ impl NgScopeArgs {
         if self.ng_log_dci_batch_size.is_none() {
             self.ng_log_dci_batch_size = config_file.ng_log_dci_batch_size;
         }
-        if self.ng_rf_args.is_none() {
-            self.ng_rf_args = config_file.ng_rf_args;
-        }
     }
 }
 
@@ -622,7 +614,6 @@ impl FlattenedNgScopeArgs {
             ng_log_file: ng_args.ng_log_file,
             ng_log_dci: ng_args.ng_log_dci.unwrap(),
             ng_log_dci_batch_size: ng_args.ng_log_dci_batch_size.unwrap(),
-            ng_rf_args: ng_args.ng_rf_args.unwrap(),
         })
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,6 @@ pub const DEFAULT_NG_LOG_FILE: &str = "./.ng_scope_log.txt";
 pub const DEFAULT_NG_START_PROCESS: bool = true;
 pub const DEFAULT_NG_LOG_DCI: bool = true;
 pub const DEFAULT_NG_LOG_DCI_BATCH_SIZE: u64 = 60000;
-pub const DEFAULT_NG_RF_ARGS: &str = "serial=3295B62";
 
 pub const DEFAULT_MATCHING_LOCAL_ADDR: &str = "0.0.0.0:9292";
 pub const DEFAULT_MATCHING_TRAFFIC_PATTERN: &[RntiMatchingTrafficPatternType] = &[RntiMatchingTrafficPatternType::A];
@@ -325,7 +324,6 @@ impl default::Default for Arguments {
                 ng_start_process: Some(DEFAULT_NG_START_PROCESS),
                 ng_log_dci: Some(DEFAULT_NG_LOG_DCI),
                 ng_log_dci_batch_size: Some(DEFAULT_NG_LOG_DCI_BATCH_SIZE),
-                ng_rf_args: Some(DEFAULT_NG_RF_ARGS.to_string()),
             }),
             rntimatching: Some(RntiMatchingArgs {
                 matching_local_addr: Some(DEFAULT_MATCHING_LOCAL_ADDR.to_string()),


### PR DESCRIPTION
When passing CLI arguments that set the value of an inner field of a nested struct, currently, all other fields of that struct also need to be set using CLI arguments, otherwise the field values will be `null`. 

Also, since afaict, `print_debug` doesn't work in `parse.rs` due to how everything is initialized, all prints were changed to `print_info` and will be printed every time. 

Not sure about URI paths, I think they were not "pbe" anymore but "l2b" in the current server/tocket, so this would also be fixed.

All default values are at the top now as const.